### PR TITLE
Fix s3cmd_source_dir default behavior

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ main() {
 
 
   if [ -z "$S3CMD_SOURCE_DIR" ]; then
-    fail 'S3CMD_SOURCE_DIR is not set. Quitting.'
+    FILES_SOURCE_DIR="./*"
   else
     FILES_SOURCE_DIR="./$S3CMD_SOURCE_DIR/*"
   fi


### PR DESCRIPTION
According with the readme, S3CMD_SOURCE_DIR should be "./" by default, but this is not happening. Instead is required as mandatory. As a result if I set it to "./", the final path is "././/myfile"

