### PR TITLE
Fix --delete-removed not working

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,7 @@ main() {
   if [ -z "$S3CMD_SOURCE_DIR" ]; then
     fail 'S3CMD_SOURCE_DIR is not set. Quitting.'
   else
-    FILES_SOURCE_DIR="./$S3CMD_SOURCE_DIR/*"
+    FILES_SOURCE_DIR="./$S3CMD_SOURCE_DIR/"
   fi
 
   if [ -n "$S3CMD_CF_INVALIDATE" ]; then


### PR DESCRIPTION
The source dir needs to end with a single "/" in order to s3cmd to work properly.

Take a look to this upstream issue: https://github.com/s3tools/s3cmd/issues/660

In my laptop:
```
s3cmd --no-preserve --verbose --check-md5 --exclude-from .s3ignore --delete-removed   sync ././* s3://mybucket
...
INFO: Summary: 0 local files to upload, 0 files to remote copy, 0 remote files to delete
```
And then without asterisk, just leaving a triling "/"
```
s3cmd --no-preserve --verbose --check-md5 --exclude-from .s3ignore --delete-removed   sync ././ s3://mybucket
INFO: Summary: 0 local files to upload, 0 files to remote copy, 1 remote files to delete
delete: 's3://mybucket/test.html'
```

Note the double "././" in the source dir, that should be fixed by applying https://github.com/ThiagoAnunciacao/s3cmd-sync-action/pull/4