### PR TITLE
Support for mime magic when --guess-mime-type is passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL maintainer="Thiago Anunciacao <thiago.anunciacao@me.com>"
 
 # https://github.com/s3tools/s3cmd/blob/master/NEWS
 
-RUN apk add --update bash
+RUN apk add --update bash libmagic
 
 RUN pip install s3cmd python-dateutil python-magic
 


### PR DESCRIPTION
When you enter `--guess-mime-type` into `S3CMD_EXTRA_OPTS` the following warning may be produced:

```
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
```

Guessing MIME types based on file extensions doesn't work when if don't have file extensions. Adding `libmagic` does the trick.